### PR TITLE
install cairo, remove R 3.6. necessary for plot tests

### DIFF
--- a/.github/workflows/R-CMD-full.yaml
+++ b/.github/workflows/R-CMD-full.yaml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 
-name: R-CMD-check
+name: R-CMD-fullcheck
 
 jobs:
   R-CMD-check:
@@ -20,12 +20,12 @@ jobs:
         config:
           - {os: macOS-latest,   r: 'devel'}
           - {os: macOS-latest,   r: '4.0'}
-          - {os: macOS-latest,   r: '3.6'}
+          #- {os: macOS-latest,   r: '3.6'}
           - {os: windows-latest, r: 'devel'}
           - {os: windows-latest, r: '4.0'}
-          - {os: windows-latest, r: '3.6'}
+          #- {os: windows-latest, r: '3.6'}
           - {os: ubuntu-16.04,   r: '4.0', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.6', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+          #- {os: ubuntu-16.04,   r: '3.6', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           #- {os: ubuntu-16.04,   r: '3.5', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           #- {os: ubuntu-16.04,   r: '3.4', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           #- {os: ubuntu-16.04,   r: '3.3', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
@@ -66,6 +66,14 @@ jobs:
           Rscript -e "remotes::install_github('r-hub/sysreqs')"
           sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
           sudo -s eval "$sysreqs"
+
+      - name: Install Cairo (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y libcairo2-dev
+
+      - name: Install Cairo (MAC)
+        if: runner.os == 'macOS'
+        run: brew install cairo
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
For testing the figures are correct, vdiffr is used which apparently needs cairo to be install on mac and linux.
removing R 3.6 as default colours changed between 3.6 and 4.0
(hopefully) this will allow the tests to run...