### PR TITLE
Start and current date for accrual_df

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: accrualPlot
 Type: Package
 Title: Accrual plots and predictions for clinical trials
-Version: 0.3.3
+Version: 0.3.4
 Authors@R: 
     c(
     person(given = "Lukas", family = "Bütikofer", role = c("cre", "aut"),

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,6 @@
 accrualPlot 0.3.4
 ------------------
-adapt options for stat and end dates accrual_create_df
+adapt options for start and end dates accrual_create_df
 
 accrualPlot 0.3.3
 ------------------

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+accrualPlot 0.3.4
+------------------
+adapt options for stat and end dates accrual_create_df
 
 accrualPlot 0.3.3
 ------------------

--- a/R/accrual_create_df.R
+++ b/R/accrual_create_df.R
@@ -3,14 +3,18 @@
 #' Creates a data frame that contains the absolute and cumululative number of patients
 #' recruited at each date from a vector with enrollment dates.
 #'
-#' @param enrollment_dates dates on which patients are enrolled as date or character vector
-#' @param start_date date when recruitment started, single character or date, if not given the first enrollment date is used
-#' @param current_date date of the data export or database freeze, single character or date, if not given the latest enrollment date is used
-#' @param force_start0 adds an extra 0 line to the accrual data frame in cases where a start date is given and
+#' @param enrollment_dates dates on which patients are enrolled, date vector
+#' @param start_date date when recruitment started. Single date (used for all sites in by), 
+#'  date vector (with the same length the number of distinct sites in by), 
+#'  "common" (first date overall) or "site" (first date for each site, default).
+#' @param current_date date of the data export or database freeze. 
+#' 	Single date, date vector (with the same length the number of distinct sites in by),
+#'  "common" (last date overall, default) or "site" (first date for each site).
+#' @param force_start0 logical, adds an extra 0 line to the accrual data frame in cases where a start date is given and
 #' corresponds to the earliest enrollment date
-#' @param by vector with centers, has to have the same length as enrollment dates,
+#' @param by vector with sites, has to have the same length as enrollment dates,
 #' generates a list with accrual data frames for each site
-#' @param overall indicates that accrual_df contains a summary with all sites (only if by is not NA)
+#' @param overall logical indicates that accrual_df contains a summary with all sites (only if by is not NA)
 #' @param name_overall name of the summary with all sites (if by is not NA and overall==TRUE)
 #'
 #' @return Returns a data frame (or a list of data frames if by is not NA)
@@ -31,8 +35,8 @@
 #' accrual_create_df(enrollment_dates,by=centers)
 #' }
 accrual_create_df <- function(enrollment_dates,
-                              start_date=NA,
-                              current_date=NA,
+                              start_date="site",
+                              current_date="common",
                               force_start0=TRUE,
                               by=NA,
                               overall=TRUE,
@@ -40,26 +44,49 @@ accrual_create_df <- function(enrollment_dates,
 
 
   check_date(enrollment_dates)
-  if (!is.na(start_date)) check_date(start_date)
-  if (!is.na(current_date)) check_date(current_date)
-
-  if (sum(!is.na(by))==0) {
-    nc<-1
-    byt<-0
+  
+   if (sum(!is.na(by))==0) {
+    nc<-1; nct<-1; byt<-0
   } else {
-    if (is.factor(by)) {
-	  lc<-levels(by)
-	} else {
-	  lc<-unique(by)
-	}
-
-    nc<-length(lc)
-    if (overall==TRUE) {
-      nc<-nc+1
-    }
+    if (is.factor(by)) {lc<-levels(by)} else {lc<-sort(unique(by))}
+	nc<-length(lc)
+    nct<-ifelse(overall==TRUE,nc+1,nc) 
     byt<-1
-  }
-
+  }	
+  
+  if (!any(start_date[1] %in% c("site","common"))) {
+	check_date(start_date)
+	check_length(start_date,by)	
+	start_date<-mult(start_date,nc)
+	if (nct>nc) {start_date<-c(start_date,min(start_date))}	
+  } else {
+	if(length(start_date)!=1) {
+		stop(paste0(start_date," should be of class Date or a single character 'common' or 'site'"))
+	}	
+	if (start_date=="common") {
+		start_date<-rep(min(enrollment_dates),nct)
+	} else {
+	   start_date<-rep(NA,nct)
+    }
+  }	
+  
+ if (!any(current_date[1] %in% c("site","common"))) {
+	check_date(current_date)
+	check_length(current_date,by)	
+	current_date<-mult(current_date,nc)
+	if (nct>nc) {current_date<-c(current_date,max(current_date))}	
+  } else {
+	if(length(current_date)!=1) {
+		stop(paste0(current_date," should be of class Date or a single character 'common' or 'site'"))
+	}
+	if (current_date=="common") {
+		current_date<-rep(max(enrollment_dates),nct)
+	} else {
+	   current_date<-rep(NA,nct)
+    }
+  }	
+  
+ 
   accrual_df<-numeric(0)
 
   for (i in 1:nc) {
@@ -80,17 +107,17 @@ accrual_create_df <- function(enrollment_dates,
     adf<-adf[order(adf$Date),]
     adf$Cumulative <- cumsum(adf$Freq)
 
-    if (!is.na(start_date)) {
-      if (start_date != min(adf$Date) | force_start0)  {
-        stopifnot(start_date <= min(adf$Date))
-        adf<-rbind(data.frame(Date=start_date,Freq=0,Cumulative=0),adf)
+    if (!is.na(start_date[i])) {
+      if (start_date[i] != min(adf$Date) | force_start0)  {
+        stopifnot(start_date[i] <= min(adf$Date))
+        adf<-rbind(data.frame(Date=start_date[i],Freq=0,Cumulative=0),adf)
       }
     }
 
-    if (!is.na(current_date)) {
-      if (current_date != max(adf$Date)) {
-        stopifnot(current_date > max(adf$Date))
-        adf<-rbind(adf,data.frame(Date=current_date,Freq=0,Cumulative=max(adf$Cumulative)))
+    if (!is.na(current_date[i])) {
+      if (current_date[i] != max(adf$Date)) {
+        stopifnot(current_date[i] > max(adf$Date))
+        adf<-rbind(adf,data.frame(Date=current_date[i],Freq=0,Cumulative=max(adf$Cumulative)))
       }
     }
 

--- a/R/accrual_create_df.R
+++ b/R/accrual_create_df.R
@@ -10,8 +10,8 @@
 #' @param current_date date of the data export or database freeze. 
 #' 	Single date, date vector (with the same length the number of distinct sites in by),
 #'  "common" (last date overall, default) or "site" (first date for each site).
-#' @param force_start0 logical, adds an extra 0 line to the accrual data frame in cases where a start date is given and
-#' corresponds to the earliest enrollment date
+#' @param force_start0 logical, adds an extra 0 line to the accrual data frame in cases 
+#'  where a start date is given and corresponds to the earliest enrollment date.
 #' @param by vector with sites, has to have the same length as enrollment dates,
 #' generates a list with accrual data frames for each site
 #' @param overall logical indicates that accrual_df contains a summary with all sites (only if by is not NA)
@@ -19,7 +19,7 @@
 #'
 #' @return Returns a data frame (or a list of data frames if by is not NA)
 #' with three columns "Date", "Freq" and "Cumulative" with each
-#' date with an accural and the absolute and cumulative number of patients accrued.
+#' date with an accrual and the absolute and cumulative number of patients accrued.
 #' @export
 #' @examples
 #' \donttest{
@@ -89,12 +89,12 @@ accrual_create_df <- function(enrollment_dates,
  
   accrual_df<-numeric(0)
 
-  for (i in 1:nc) {
+  for (i in 1:nct) {
 
     if (byt==0) {
       ed<-enrollment_dates
     } else {
-      if (overall==TRUE & i==nc) {
+      if (overall==TRUE & i==nct) {
         ed<-enrollment_dates
       } else {
         ed<-enrollment_dates[by==lc[i]]
@@ -125,7 +125,7 @@ accrual_create_df <- function(enrollment_dates,
       accrual_df<-adf
     } else {
       accrual_df<-append(accrual_df,list(adf))
-      if (overall==TRUE & i==nc) {
+      if (overall==TRUE & i==nct) {
         names(accrual_df)[i]<-name_overall
       } else {
         names(accrual_df)[i]<-lc[i]

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -7,5 +7,28 @@ check_date <- function(x){
 }
 
 
+check_length <- function(x,y) {
+  var1 <- as.character(sys.call())[2]
+  var2 <- as.character(sys.call())[3]
+  if (all(is.na(y))) { 
+    if (length(x)!=1) stop(paste0(x," should be of length 1 if ",var2,"=NA"))
+  } else {
+    if (length(x)!=1 & length(x)!=length(unique(y))) {
+  	  stop(paste0(var1," should be of length 1 or ",length(unique(y)),
+		" (the number of distinct centers in ",var2,")."))
+  	}
+  }
+}	
+	
 
+mult<-function(x,n) {
+  var1 <- as.character(sys.call())[2]
+  
+  if (all(is.na(x)) | length(x)==1) {
+  		x<-rep(x,n)
+  } else {
+  	if (length(x)!=n) warning(paste0(var1," is not of length ",n))
+  }
+  return(x)
+}
 

--- a/man/accrual_create_df.Rd
+++ b/man/accrual_create_df.Rd
@@ -6,8 +6,8 @@
 \usage{
 accrual_create_df(
   enrollment_dates,
-  start_date = NA,
-  current_date = NA,
+  start_date = "site",
+  current_date = "common",
   force_start0 = TRUE,
   by = NA,
   overall = TRUE,
@@ -15,26 +15,30 @@ accrual_create_df(
 )
 }
 \arguments{
-\item{enrollment_dates}{dates on which patients are enrolled as date or character vector}
+\item{enrollment_dates}{dates on which patients are enrolled, date vector}
 
-\item{start_date}{date when recruitment started, single character or date, if not given the first enrollment date is used}
+\item{start_date}{date when recruitment started. Single date (used for all sites in by), 
+date vector (with the same length the number of distinct sites in by), 
+"common" (first date overall) or "site" (first date for each site, default).}
 
-\item{current_date}{date of the data export or database freeze, single character or date, if not given the latest enrollment date is used}
+\item{current_date}{date of the data export or database freeze. 
+   Single date, date vector (with the same length the number of distinct sites in by),
+"common" (last date overall, default) or "site" (first date for each site).}
 
-\item{force_start0}{adds an extra 0 line to the accrual data frame in cases where a start date is given and
-corresponds to the earliest enrollment date}
+\item{force_start0}{logical, adds an extra 0 line to the accrual data frame in cases 
+where a start date is given and corresponds to the earliest enrollment date.}
 
-\item{by}{vector with centers, has to have the same length as enrollment dates,
+\item{by}{vector with sites, has to have the same length as enrollment dates,
 generates a list with accrual data frames for each site}
 
-\item{overall}{indicates that accrual_df contains a summary with all sites (only if by is not NA)}
+\item{overall}{logical indicates that accrual_df contains a summary with all sites (only if by is not NA)}
 
 \item{name_overall}{name of the summary with all sites (if by is not NA and overall==TRUE)}
 }
 \value{
 Returns a data frame (or a list of data frames if by is not NA)
 with three columns "Date", "Freq" and "Cumulative" with each
-date with an accural and the absolute and cumulative number of patients accrued.
+date with an accrual and the absolute and cumulative number of patients accrued.
 }
 \description{
 Creates a data frame that contains the absolute and cumululative number of patients


### PR DESCRIPTION
Allow a vector of start and current dates and further options "common" and "site" using a common or a site-specific start and current dates. Defaults changed to "site" for start and "common" for current.